### PR TITLE
Sticky Modals

### DIFF
--- a/css/scojs.css
+++ b/css/scojs.css
@@ -1,8 +1,8 @@
 /* sco.modal.js */
-.modal-fixed {
+.modal-sticky {
 	position: absolute;
 }
-.modal-fixed .modal-body {
+.modal-sticky .modal-body {
 	overflow: hidden;
 	max-height: none;
 }

--- a/js/sco.modal.js
+++ b/js/sco.modal.js
@@ -74,8 +74,8 @@
 				this.$modal.css({'top': this.options.top});
 			}
 			
-			if (this.options.fixed !== undefined) {
-				this.$modal.addClass('modal-fixed');
+			if (this.options.sticky !== undefined) {
+				this.$modal.addClass('modal-sticky');
 				if (this.options.top !== undefined) {
 					this.$modal.css({'top': $(window).scrollTop() + this.options.top});
 				} else {


### PR DESCRIPTION
An option to absolutely position modals so they sitck to the page as is scrolls. This removes the need to have scroll bars on modals with taller content and gets around scroll issues for mobiles with no or poor support for overflow: scroll;
