### PR TITLE
Introduces granular setting to countdown

### DIFF
--- a/js/sco.countdown.js
+++ b/js/sco.countdown.js
@@ -33,11 +33,11 @@
       ,keepGoing = function() { return left[data.granularity] == null }
       ,getRefreshTime = function() {
         if (data.granularity === 'd')
-          return Math.floor(secondsLeft % 86400) || 1;
+          return left.d ? (secondsLeft % 86400 || 1) : 1;
         if (data.granularity === 'h')
-          return Math.floor(secondsLeft % 3600) || 1;
+          return left.h ? (secondsLeft % 3600 || 1) : 1;
         if (data.granularity === 'm')
-          return Math.floor(secondsLeft % 60) || 1;
+          return left.m ? (secondsLeft % 60 || 1) : 1;
 
         return 1;
       };


### PR DESCRIPTION
Hi! Nice job with these plugins. I've added a 'granular' option to the countdown, which stops the string calculation at hours if there is more than a day left, and will only run the code to update on the hour change.

This can obviously be extended for any level of granularity and I'm happy to do so if you feel its a good idea.
